### PR TITLE
Not Create Preview Branch for PR

### DIFF
--- a/.github/workflows/AllUp.yml
+++ b/.github/workflows/AllUp.yml
@@ -39,11 +39,14 @@ jobs:
           GITHUB_REF: ${{ github.ref }}
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
       - uses: actions4git/setup-git@v1
+        if: github.ref == 'refs/heads/main'
       - run: |
-          git checkout --orphan artifact/${{ github.ref }}
+          git checkout --orphan artifact
+          git rm rf .
           git add AllUp.wikitext
           git commit -m "Update data"
-          git push --force origin artifact/${{ github.ref }}
+          git push --force origin artifact
+        if: github.ref == 'refs/heads/main'
       - name: Preview on Pull Request
         if: ${{ github.event_name == 'pull_request' }}
         uses: thollander/actions-comment-pull-request@v2.4.2

--- a/.github/workflows/AllUp.yml
+++ b/.github/workflows/AllUp.yml
@@ -42,7 +42,7 @@ jobs:
         if: github.ref == 'refs/heads/main'
       - run: |
           git checkout --orphan artifact
-          git rm rf .
+          git rm -rf .
           git add AllUp.wikitext
           git commit -m "Update data"
           git push --force origin artifact


### PR DESCRIPTION
fix #111 

After the modification, **GitHub Actions will not create preview branch for each branch other than main.**

## Summary by Sourcery

CI:
- Modify GitHub Actions workflow to prevent the creation of preview branches for branches other than 'main'.