### PR TITLE
Use X-authkey to interact with Satwiki

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "cron"
-      cronjob: "26 1 * * 5"
+      cronjob: "0 16 * * 5"
       timezone: "Asia/Shanghai"
     reviewers:
       - "yusancky"
@@ -14,7 +14,7 @@ updates:
     directory: "/"
     schedule:
       interval: "cron"
-      cronjob: "26 1 * * 5"
+      cronjob: "0 16 * * 5"
       timezone: "Asia/Shanghai"
     reviewers:
       - "yusancky"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,8 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
-      time: "06:00"
+      interval: "cron"
+      cronjob: "26 1 * * 5"
       timezone: "Asia/Shanghai"
     reviewers:
       - "yusancky"
@@ -13,8 +13,8 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "daily"
-      time: "06:00"
+      interval: "cron"
+      cronjob: "26 1 * * 5"
       timezone: "Asia/Shanghai"
     reviewers:
       - "yusancky"

--- a/.github/workflows/AllUp.yml
+++ b/.github/workflows/AllUp.yml
@@ -1,5 +1,4 @@
 name: AllUp
-
 on:
   push:
     branches: [ main ]
@@ -11,29 +10,22 @@ on:
   schedule:
     - cron: '26 1 * * 5'
   workflow_dispatch:
-
 permissions:
   contents: write
   pull-requests: write
-
 env:
   TZ: Asia/Shanghai
-
 jobs:
   AllUp:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4.2.2
-      - name: Setup Python
-        uses: actions/setup-python@v5.6.0
+      - uses: actions/checkout@v4.2.2
+      - uses: actions/setup-python@v5.6.0
         with:
-          python-version: '3.12'
+          python-version: '3.13'
           cache: 'pip'
-      - name: Install Python Dependencies
-        run: pip install -r requirements.txt
-      - name: Main
-        run: python main.py
+      - run: pip install -r requirements.txt
+      - run: python main.py
         env:
           BOT_PASSWORD: ${{ secrets.BOT_PASSWORD }}
           X_AUTHKEY: ${{ secrets.X_AUTHKEY }}

--- a/.github/workflows/AllUp.yml
+++ b/.github/workflows/AllUp.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Main
         run: python main.py
         env:
+          BOT_PASSWORD: ${{ secrets.BOT_PASSWORD }}
           X_AUTHKEY: ${{ secrets.X_AUTHKEY }}
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           GITHUB_REF: ${{ github.ref }}

--- a/.github/workflows/AllUp.yml
+++ b/.github/workflows/AllUp.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Main
         run: python main.py
         env:
+          X_AUTHKEY: ${{ secrets.X_AUTHKEY }}
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           GITHUB_REF: ${{ github.ref }}
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}

--- a/.github/workflows/AllUp.yml
+++ b/.github/workflows/AllUp.yml
@@ -8,7 +8,7 @@ on:
       - synchronize
       - reopened
   schedule:
-    - cron: '26 1 * * 5'
+    - cron: '26 1 * * *'
   workflow_dispatch:
 permissions:
   contents: write

--- a/AllUp_utils/web.py
+++ b/AllUp_utils/web.py
@@ -1,17 +1,27 @@
-# Copyright (c) yusancky. All rights reserved. 
-# Licensed under the Apache License 2.0. See License in the project root for license information. 
+# Copyright (c) yusancky. All rights reserved.
+# Licensed under the Apache License 2.0. See License in the project root for license information.
 
 from requests import get
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
 
+
 def configure_chromedriver():
     chrome_options = Options()
-    for option in ['--headless','--disable-gpu','--window-size=1920,1200','--ignore-certificate-errors','--disable-extensions','--no-sandbox','--disable-dev-shm-usage']:
+    for option in [
+        "--headless",
+        "--disable-gpu",
+        "--window-size=1920,1200",
+        "--ignore-certificate-errors",
+        "--disable-extensions",
+        "--no-sandbox",
+        "--disable-dev-shm-usage",
+    ]:
         chrome_options.add_argument(option)
-    return webdriver.Chrome(options = chrome_options)
+    return webdriver.Chrome(options=chrome_options)
 
-def fetch_data(url : str,need_selenium = False):
+
+def fetch_data(url: str, need_selenium=False):
     if need_selenium:
         need_selenium.get(url)
         return need_selenium.page_source

--- a/AllUp_utils/wiki.py
+++ b/AllUp_utils/wiki.py
@@ -1,30 +1,50 @@
-# Copyright (c) yusancky. All rights reserved. 
-# Licensed under the Apache License 2.0. See License in the project root for license information. 
+# Copyright (c) yusancky. All rights reserved.
+# Licensed under the Apache License 2.0. See License in the project root for license information.
 
 from os import environ
 import requests
 from pwiki.wiki import Wiki
 
-def PR_TEST():
-    return environ['GITHUB_EVENT_NAME'] == 'pull_request'
+try:
+    MAIN_REPO_BRANCH = (
+        environ["GITHUB_REPOSITORY_OWNER"] == "yusancky"
+        and environ["GITHUB_REF"] == "refs/heads/main"
+    )
+    TEST_DISPATCH = (
+        environ["GITHUB_REPOSITORY_OWNER"] == "yusancky"
+        and environ["GITHUB_EVENT_NAME"] == "workflow_dispatch"
+    )
+    TEST_PR = environ["GITHUB_EVENT_NAME"] == "pull_request"
+except Exception:
+    MAIN_REPO_BRANCH, TEST_DISPATCH, TEST_PR = False, False, False
 
-def MAIN_REPO_BRANCH():
-    return (environ['GITHUB_REF'] == 'refs/heads/main' and environ['GITHUB_REPOSITORY_OWNER'] == 'yusancky')
-
-# Monkeypatch requests.Session to always include X-authkey
 _original_session_init = requests.Session.__init__
+
 
 def _patched_session_init(self, *args, **kwargs):
     _original_session_init(self, *args, **kwargs)
-    self.headers["X-authkey"] = environ['X_AUTHKEY']
+    self.headers["X-authkey"] = environ["X_AUTHKEY"]
+
 
 requests.Session.__init__ = _patched_session_init
 
-def pull(title : str,split_line = False):
-    wiki = Wiki('sat.huijiwiki.com', '雨伞CKY', environ['BOT_PASSWORD'])
-    return wiki.page_text(title)
+if MAIN_REPO_BRANCH or PR_TEST:
+    wiki = Wiki("sat.huijiwiki.com", "雨伞CKY", environ["BOT_PASSWORD"])
 
-def push(title : str,content_id : str,content : str):
-    open(f'{title}.wikitext', 'w').write(content)
-    if PR_TEST():
-        print(f'### {content_id}\n\n```go\n{content}\n```\n\n',file = open('PR_preview.md','a'))
+
+def pull(title: str, split_line=False):
+    if MAIN_REPO_BRANCH or TEST_DISPATCH or TEST_PR:
+        return wiki.page_text(title)
+    else:
+        return ""
+
+
+def push(title: str, content_id: str, content: str):
+    open(f"{title}.wikitext", "w").write(content)
+    if MAIN_REPO_BRANCH or TEST_DISPATCH:
+        wiki.edit(title, content, "Edit via AllUp-Satwiki")
+    if TEST_PR:
+        print(
+            f"### {content_id}\n\n```go\n{content}\n```\n\n",
+            file=open("PR_preview.md", "a"),
+        )

--- a/AllUp_utils/wiki.py
+++ b/AllUp_utils/wiki.py
@@ -28,7 +28,7 @@ def _patched_session_init(self, *args, **kwargs):
 
 requests.Session.__init__ = _patched_session_init
 
-if MAIN_REPO_BRANCH or TEST_PR:
+if MAIN_REPO_BRANCH or TEST_DISPATCH or TEST_PR:
     wiki = Wiki("sat.huijiwiki.com", "雨伞CKY", environ["BOT_PASSWORD"])
 
 

--- a/AllUp_utils/wiki.py
+++ b/AllUp_utils/wiki.py
@@ -2,8 +2,8 @@
 # Licensed under the Apache License 2.0. See License in the project root for license information.
 
 from os import environ
-import requests
 from pwiki.wiki import Wiki
+import requests
 
 try:
     MAIN_REPO_BRANCH = (

--- a/AllUp_utils/wiki.py
+++ b/AllUp_utils/wiki.py
@@ -12,6 +12,7 @@ def MAIN_REPO_BRANCH():
     
 def pull(title : str,split_line = False):
     wiki = Wiki('sat.huijiwiki.com')
+    wiki.client.headers["X-authkey"] = environ['X_AUTHKEY']
     return wiki.page_text(title)
 
 def push(title : str,content_id : str,content : str):

--- a/AllUp_utils/wiki.py
+++ b/AllUp_utils/wiki.py
@@ -9,13 +9,19 @@ def PR_TEST():
 
 def MAIN_REPO_BRANCH():
     return (environ['GITHUB_REF'] == 'refs/heads/main' and environ['GITHUB_REPOSITORY_OWNER'] == 'yusancky')
-    
-def pull(title : str,split_line = False):
-    wiki = Wiki('sat.huijiwiki.com', '雨伞CKY', environ['BOT_PASSWORD'])
-    wiki.client.headers["X-authkey"] = environ['X_AUTHKEY']
+
+# Subclass Wiki to inject X-authkey header prior to first request
+class AuthWiki(Wiki):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.client.headers["X-authkey"] = environ['X_AUTHKEY']
+
+def pull(title: str, split_line=False):
+    # Use AuthWiki instead of Wiki
+    wiki = AuthWiki('sat.huijiwiki.com', '雨伞CKY', environ['BOT_PASSWORD'])
     return wiki.page_text(title)
 
-def push(title : str,content_id : str,content : str):
+def push(title: str, content_id: str, content: str):
     open(f'{title}.wikitext', 'w').write(content)
     if PR_TEST():
-        print(f'### {content_id}\n\n```go\n{content}\n```\n\n',file = open('PR_preview.md','a'))
+        print(f'### {content_id}\n\n```go\n{content}\n```\n\n', file=open('PR_preview.md', 'a'))

--- a/AllUp_utils/wiki.py
+++ b/AllUp_utils/wiki.py
@@ -11,7 +11,7 @@ def MAIN_REPO_BRANCH():
     return (environ['GITHUB_REF'] == 'refs/heads/main' and environ['GITHUB_REPOSITORY_OWNER'] == 'yusancky')
     
 def pull(title : str,split_line = False):
-    wiki = Wiki('sat.huijiwiki.com')
+    wiki = Wiki('sat.huijiwiki.com', '雨伞CKY', environ['BOT_PASSWORD'])
     wiki.client.headers["X-authkey"] = environ['X_AUTHKEY']
     return wiki.page_text(title)
 

--- a/AllUp_utils/wiki.py
+++ b/AllUp_utils/wiki.py
@@ -11,19 +11,8 @@ def MAIN_REPO_BRANCH():
     return (environ['GITHUB_REF'] == 'refs/heads/main' and environ['GITHUB_REPOSITORY_OWNER'] == 'yusancky')
     
 def pull(title : str,split_line = False):
-    if MAIN_REPO_BRANCH() or PR_TEST():
-        print('Unable to find test sources.')
-        try:
-            wiki = Wiki('sat.huijiwiki.com')
-            return wiki.page_text(title)
-        except:
-            print(f'You do not have permission to get password.\nREF: {environ["GITHUB_REF"]}\nREPO_OWNER: {environ["GITHUB_REPOSITORY_OWNER"]}')
-    else:
-        try:
-            wiki = Wiki('sat.huijiwiki.com')
-            return wiki.page_text(title)
-        except:
-            print(f'You do not have permission to get password.\nREF: {environ["GITHUB_REF"]}\nREPO_OWNER: {environ["GITHUB_REPOSITORY_OWNER"]}')
+    wiki = Wiki('sat.huijiwiki.com')
+    return wiki.page_text(title)
 
 def push(title : str,content_id : str,content : str):
     open(f'{title}.wikitext', 'w').write(content)

--- a/AllUp_utils/wiki.py
+++ b/AllUp_utils/wiki.py
@@ -28,7 +28,7 @@ def _patched_session_init(self, *args, **kwargs):
 
 requests.Session.__init__ = _patched_session_init
 
-if MAIN_REPO_BRANCH or PR_TEST:
+if MAIN_REPO_BRANCH or TEST_PR:
     wiki = Wiki("sat.huijiwiki.com", "雨伞CKY", environ["BOT_PASSWORD"])
 
 

--- a/AllUp_utils/wikitext.py
+++ b/AllUp_utils/wikitext.py
@@ -1,16 +1,19 @@
-# Copyright (c) yusancky. All rights reserved. 
-# Licensed under the Apache License 2.0. See License in the project root for license information. 
+# Copyright (c) yusancky. All rights reserved.
+# Licensed under the Apache License 2.0. See License in the project root for license information.
+
 
 def build_switch(data_map):
-    result = '{{#switch:{{{' + data_map['switch_key'] + '|}}}'
-    for data_key,data_value in data_map.items():
-        if data_key == 'switch_key':
+    result = "{{#switch:{{{" + data_map["switch_key"] + "|}}}"
+    for data_key, data_value in data_map.items():
+        if data_key == "switch_key":
             continue
-        if isinstance(data_value,str):
-            result += f'|{data_key}={data_value}'
-        elif isinstance(data_value,dict):
-            result += f'|{data_key}={build_switch(data_value)}'
+        if isinstance(data_value, str):
+            result += f"|{data_key}={data_value}"
+        elif isinstance(data_value, dict):
+            result += f"|{data_key}={build_switch(data_value)}"
         else:
-            raise TypeError(f"A string or a dictionary is required, not '{type(data_value)}'.")
-    result += '}}'
+            raise TypeError(
+                f"A string or a dictionary is required, not '{type(data_value)}'."
+            )
+    result += "}}"
     return result

--- a/README.md
+++ b/README.md
@@ -2,16 +2,8 @@
 
 ![Python: 3.12 | 3.13 | 3.14](https://img.shields.io/badge/Python-3.12%20%7C%203.13%20%7C%203.14-python?style=social&logo=python&logoColor=blue) ![License: Apache-2.0](https://img.shields.io/github/license/yusancky/AllUp-Satwiki?style=social)
 
-AllUp 项目是由 [雨伞CKY](https://github.com/yusancky) 维护的、自动化爬取并集合数据以便动态更新的项目。<!--AllUp 项目的数据将于每日北京时间 9 时 26 分爬取数据并修改。[^1]-->由于近日 GitHub Actions 运行器未能与灰机 wiki 服务器进行成功连接，近期无法推送内容至卫星百科。
+AllUp-Satwiki 项目是由 [雨伞CKY](https://github.com/yusancky) 维护的、自动化爬取并集合数据以便动态更新的项目，其于北京时间每天 9 时 26 分获取数据并同步到卫星百科。[^1]
 
 ![Contributions in the Last 30 Days](https://repobeats.axiom.co/api/embed/3c013245586cfcc386dd553450db134d7617991c.svg)
 
-# 使用
-
-克隆或下载本存储库后，（切换到本项目根目录后）使用 `pip install -r requirements.txt` 安装所有依赖。之后，你可以分别通过运行 `main.py` 和 `TSS/main.py` 生成主模板内容、天宫空间站任务列表的 Apache ECharts 模板内容。生成的内容不会主动输出。
-
-# 贡献
-
-请前往 [贡献文档](/.github/CONTRIBUTING.md) 查看贡献相关内容。
-
-[^1]: 定时进行任务基于 GitHub Action 的 `schedule` 事件。但 `schedule` 事件在 Actions 工作流运行期间负载过高时可能会延迟。据以往经历，一般延迟在 30 分钟至 45 分钟。
+[^1]: 定时任务基于 GitHub Actions 的 `schedule` 事件，但其在 Actions 工作流运行负载过高时可能会延迟。

--- a/main.py
+++ b/main.py
@@ -236,4 +236,4 @@ if __name__ == "__main__":
     for dataset in ["t"] + [str(i + 1) for i in range(5)] + ["#default"]:
         AllUp_data[dataset] = make(dataset)
     AllUp_content = f"<includeonly>{AllUp_utils.wikitext.build_switch(AllUp_data)}</includeonly><noinclude>[[Category:模板]]{{{{documentation}}}}</noinclude>"
-    AllUp_utils.wiki.push("AllUp", "MAIN", AllUp_content)
+    AllUp_utils.wiki.push("Template:AllUp", "MAIN", AllUp_content)

--- a/main.py
+++ b/main.py
@@ -161,9 +161,9 @@ def make(id):
       return '请输入正确的AllUp编号！'
 
 if __name__ == '__main__':
-  chromedriver = AllUp_utils.web.configure_chromedriver()
-  AllUp_data = {'switch_key': '1'}
-  for dataset in ['t'] + [str(i + 1) for i in range(5)] + ['#default']:
-    AllUp_data[dataset] = make(dataset)
-  AllUp_content = f'<includeonly>{AllUp_utils.wikitext.build_switch(AllUp_data)}</includeonly><noinclude>[[Category:模板]]{{{{documentation}}}}</noinclude>'
-  AllUp_utils.wiki.push('AllUp', 'MAIN', AllUp_content)
+  print('001')
+  test = AllUp_utils.wiki.pull('神舟二十号')
+  print('002')
+  print(test)
+  print('003')
+  print('000')

--- a/main.py
+++ b/main.py
@@ -68,7 +68,8 @@ def build_tiangong_chart():
     """Build Tiangong Space Station missions chart."""
     missions = []
     today = date.today()
-    dataset = [line.strip() for line in open("TSS-data/TSS-data.wikitext")]
+    with open("TSS-data/TSS-data.wikitext", encoding="utf-8") as f:
+        dataset = [line.strip() for line in f]
     for row in dataset:
         data = row.split(",")
         start_date = date.fromisoformat(data[2])

--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
-# Copyright (c) yusancky. All rights reserved. 
-# Licensed under the Apache License 2.0. See License in the project root for license information. 
+# Copyright (c) yusancky. All rights reserved.
+# Licensed under the Apache License 2.0. See License in the project root for license information.
 
 import AllUp_utils.wiki
 import AllUp_utils.web
@@ -8,63 +8,95 @@ from datetime import date
 from re import compile, findall
 from time import localtime, strftime
 
+
 def fetch_voyager_data():
-  """[Deprecated] Fetch Voyager mission data."""
-  web_data = AllUp_utils.web.fetch_data('https://voyager.jpl.nasa.gov/mission/status/')
-  data = {'switch_key': 'id'}
-  for id in [str(i + 1) for i in range(2)]:
-    data[id] = {'switch_key': 'section'}
-    for section in ['km', 'au', 'kms', 'aus', 'speed', 'lt']:
-      data[id][section] = findall(
-        compile(f'id="voy{id}_{section}">(.*)</div>'),
-        web_data
-      )[0]
-    data[id]['#default'] = '请输入正确的选项名！'
-  data['#default'] = '请输入正确的编号！'
-  return AllUp_utils.wikitext.build_switch(data)
+    """[Deprecated] Fetch Voyager mission data."""
+    web_data = AllUp_utils.web.fetch_data(
+        "https://voyager.jpl.nasa.gov/mission/status/"
+    )
+    data = {"switch_key": "id"}
+    for id in [str(i + 1) for i in range(2)]:
+        data[id] = {"switch_key": "section"}
+        for section in ["km", "au", "kms", "aus", "speed", "lt"]:
+            data[id][section] = findall(
+                compile(f'id="voy{id}_{section}">(.*)</div>'), web_data
+            )[0]
+        data[id]["#default"] = "请输入正确的选项名！"
+    data["#default"] = "请输入正确的编号！"
+    return AllUp_utils.wikitext.build_switch(data)
+
 
 def fetch_orbital_data():
-  """Fetch orbital data."""
-  web_data = AllUp_utils.web.fetch_data('https://in-the-sky.org/spacecraft.php?id=6073')
-  data = {'switch_key': 'section'}
-  for section in ['Inclination', 'Eccentricity', 'RA ascending node', 'Argument perigee', 'Mean anomaly', 'Orbital period', 'Epoch of osculation']:
-    data[section] = findall(f'<td>{section}</td>\n *<td>([^<>]*)</td>', web_data)[0].strip()
-  data['#default'] = '请输入正确的选项名！'
-  return AllUp_utils.wikitext.build_switch(data)
+    """Fetch orbital data."""
+    web_data = AllUp_utils.web.fetch_data(
+        "https://in-the-sky.org/spacecraft.php?id=6073"
+    )
+    data = {"switch_key": "section"}
+    for section in [
+        "Inclination",
+        "Eccentricity",
+        "RA ascending node",
+        "Argument perigee",
+        "Mean anomaly",
+        "Orbital period",
+        "Epoch of osculation",
+    ]:
+        data[section] = findall(
+            f"<td>{section}</td>\n *<td>([^<>]*)</td>", web_data
+        )[0].strip()
+    data["#default"] = "请输入正确的选项名！"
+    return AllUp_utils.wikitext.build_switch(data)
+
 
 def fetch_starlink_data():
-  """Fetch Starlink mission data."""
-  web_data = AllUp_utils.web.fetch_data('https://planet4589.org/space/con/star/stats.html')
-  data = {'switch_key': 'section'}
-  dataset = findall(r'<TR><TD>Total</TD><TD style="color:blue" *>(\d*)</TD><TD style="color:red" *>\d*</TD><TD style="color:red" *>\d*</TD><TD style="color:red" *>\d*</TD><TD style="color:red" *>\d*</TD><TD style="color:blue" *>(\d*)</TD><TD style="color:blue" *>(\d*)</TD><TD style="color:red" *>\d*</TD><TD style="color:red" *>\d*</TD><TD style="color:red" *>\d*</TD><TD style="color:blue" *>(\d*)</TD><TD style="color:blue" *>\d*</TD><TD style="color:blue" *>\d*</TD><TD style="color:blue" *>\d*</TD><TD style="color:blue" *>\d*</TD><TD style="color:blue" *>\d*</TD><TD style="color:green" *>\d*</TD><TD style="color:green" *>\d*</TD><TD style="color:green" *>\d*</TD><TD style="color:green" *> *</TD><TD style="color:green" *> *</TD><TD style="color:green" *> *</TD></TR>',web_data)
-  for section in range(4):
-    data[str(section + 1)] = dataset[0][section]
-  data['#default'] = '请输入正确的选项名！'
-  return AllUp_utils.wikitext.build_switch(data)
+    """Fetch Starlink mission data."""
+    web_data = AllUp_utils.web.fetch_data(
+        "https://planet4589.org/space/con/star/stats.html"
+    )
+    data = {"switch_key": "section"}
+    dataset = findall(
+        r'<TR><TD>Total</TD><TD style="color:blue" *>(\d*)</TD><TD style="color:red" *>\d*</TD><TD style="color:red" *>\d*</TD><TD style="color:red" *>\d*</TD><TD style="color:red" *>\d*</TD><TD style="color:blue" *>(\d*)</TD><TD style="color:blue" *>(\d*)</TD><TD style="color:red" *>\d*</TD><TD style="color:red" *>\d*</TD><TD style="color:red" *>\d*</TD><TD style="color:blue" *>(\d*)</TD><TD style="color:blue" *>\d*</TD><TD style="color:blue" *>\d*</TD><TD style="color:blue" *>\d*</TD><TD style="color:blue" *>\d*</TD><TD style="color:blue" *>\d*</TD><TD style="color:green" *>\d*</TD><TD style="color:green" *>\d*</TD><TD style="color:green" *>\d*</TD><TD style="color:green" *> *</TD><TD style="color:green" *> *</TD><TD style="color:green" *> *</TD></TR>',
+        web_data,
+    )
+    for section in range(4):
+        data[str(section + 1)] = dataset[0][section]
+    data["#default"] = "请输入正确的选项名！"
+    return AllUp_utils.wikitext.build_switch(data)
+
 
 def build_tiangong_chart():
-  """Build Tiangong missions chart."""
-  missions = []
-  today = date.today()
-  dataset = [line.strip() for line in open('TSS-data/TSS-data.wikitext')]
-  for row in dataset:
-    data = row.split(',')
-    start_date = date.fromisoformat(data[2])
-    end_date = date.fromisoformat(data[3]) if data[3] != 'future' else today
-    delta_days = (end_date - start_date).days
-    missions.append([
-      data[0],
-      start_date,
-      delta_days,
-      '#fdba74' if data[1] == 'main' else ('#6ee7b7' if data[3] != 'future' else '#fcd34d')
-    ])
-  data_name,start_date,delta_days_with_data_color = [],[],''
-  for mission in missions:
-    data_name.insert(0,mission[0])
-    start_date.insert(0,(mission[1] - date.fromisoformat('20210429')).days)
-    delta_days_with_data_color = f'{{"value": {mission[2]}, "itemStyle": {{"color": "{mission[3]}"}} }},{delta_days_with_data_color}'
-  delta_days_with_data_color = delta_days_with_data_color[:-1]
-  return f'''{{{{#echarts:option={{
+    """Build Tiangong Space Station missions chart."""
+    missions = []
+    today = date.today()
+    dataset = [line.strip() for line in open("TSS-data/TSS-data.wikitext")]
+    for row in dataset:
+        data = row.split(",")
+        start_date = date.fromisoformat(data[2])
+        end_date = (
+            date.fromisoformat(data[3]) if data[3] != "future" else today
+        )
+        delta_days = (end_date - start_date).days
+        missions.append(
+            [
+                data[0],
+                start_date,
+                delta_days,
+                (
+                    "#fdba74"
+                    if data[1] == "main"
+                    else ("#6ee7b7" if data[3] != "future" else "#fcd34d")
+                ),
+            ]
+        )
+    data_name, start_date, delta_days_with_data_color = [], [], ""
+    for mission in missions:
+        data_name.insert(0, mission[0])
+        start_date.insert(
+            0, (mission[1] - date.fromisoformat("20210429")).days
+        )
+        delta_days_with_data_color = f'{{"value": {mission[2]}, "itemStyle": {{"color": "{mission[3]}"}} }},{delta_days_with_data_color}'
+    delta_days_with_data_color = delta_days_with_data_color[:-1]
+    return f"""{{{{#echarts:option={{
   "title": {{
     "text": "天宫空间站任务列表",
     "subtext": "上次更新：{date.today().year}年{date.today().month}月{date.today().day}日（{(date.today() - date.fromisoformat('20210429')).days}）"
@@ -122,48 +154,85 @@ def build_tiangong_chart():
     }}
   ]
 }}
-|style=min-height:380px}}}}'''
+|style=min-height:380px}}}}"""
+
 
 def fetch_satellite_data():
-  """Fetch data for multiple satellites."""
-  data = {'switch_key': 'sat'}
-  for sat in ['star', 'ow', 'kp', 'stsh', 'xw', 'qf', 'ynh', 'lynk', 'esp', 's1m', 'pln', 'iri', 'gbl', 'jil', 'slog', 'asts', 'swa', 'glo', 'spr', 'st3', 'par', 'gps', 'bei', 'oco', 'hwk', 'kep', 'int', 'ses']:
-    web_data = AllUp_utils.web.fetch_data(f'https://planet4589.org/space/con/{sat}/stats.html')
-    data_inner = {'switch_key': 'section'}
-    dataset = findall(r'<TR><TD>Total</TD><TD style="color:blue" *>(\d*)</TD><TD style="color:red" *>\d*</TD><TD style="color:red" *>\d*</TD><TD style="color:red" *>\d*</TD><TD style="color:red" *>\d*</TD><TD style="color:blue" *>(\d*)</TD><TD style="color:blue" *>(\d*)</TD><TD style="color:red" *>\d*</TD><TD style="color:red" *>\d*</TD><TD style="color:red" *>\d*</TD><TD style="color:blue" *>(\d*)</TD><TD style="color:blue" *>\d*</TD><TD style="color:blue" *>\d*</TD><TD style="color:blue" *>\d*</TD><TD style="color:blue" *>\d*</TD><TD style="color:blue" *>\d*</TD><TD style="color:green" *>\d*</TD><TD style="color:green" *>\d*</TD><TD style="color:green" *>\d*</TD><TD style="color:green" *> *</TD><TD style="color:green" *> *</TD><TD style="color:green" *> *</TD></TR>',web_data)
-    for section in range(4):
-      try:
-        data_inner[str(section + 1)] = dataset[0][section]
-      except Exception as e:
-        data_inner[str(section + 1)] = str(e)
-    data_inner['#default'] = '请输入正确的选项名！'
-    data[sat] = AllUp_utils.wikitext.build_switch(data_inner)
-  data['#default'] = '请输入正确的卫星名！'
-  return AllUp_utils.wikitext.build_switch(data)
+    """Fetch data for multiple satellites."""
+    data = {"switch_key": "sat"}
+    for sat in [
+        "star",
+        "ow",
+        "kp",
+        "stsh",
+        "xw",
+        "qf",
+        "ynh",
+        "lynk",
+        "esp",
+        "s1m",
+        "pln",
+        "iri",
+        "gbl",
+        "jil",
+        "slog",
+        "asts",
+        "swa",
+        "glo",
+        "spr",
+        "st3",
+        "par",
+        "gps",
+        "bei",
+        "oco",
+        "hwk",
+        "kep",
+        "int",
+        "ses",
+    ]:
+        web_data = AllUp_utils.web.fetch_data(
+            f"https://planet4589.org/space/con/{sat}/stats.html"
+        )
+        data_inner = {"switch_key": "section"}
+        dataset = findall(
+            r'<TR><TD>Total</TD><TD style="color:blue" *>(\d*)</TD><TD style="color:red" *>\d*</TD><TD style="color:red" *>\d*</TD><TD style="color:red" *>\d*</TD><TD style="color:red" *>\d*</TD><TD style="color:blue" *>(\d*)</TD><TD style="color:blue" *>(\d*)</TD><TD style="color:red" *>\d*</TD><TD style="color:red" *>\d*</TD><TD style="color:red" *>\d*</TD><TD style="color:blue" *>(\d*)</TD><TD style="color:blue" *>\d*</TD><TD style="color:blue" *>\d*</TD><TD style="color:blue" *>\d*</TD><TD style="color:blue" *>\d*</TD><TD style="color:blue" *>\d*</TD><TD style="color:green" *>\d*</TD><TD style="color:green" *>\d*</TD><TD style="color:green" *>\d*</TD><TD style="color:green" *> *</TD><TD style="color:green" *> *</TD><TD style="color:green" *> *</TD></TR>',
+            web_data,
+        )
+        for section in range(4):
+            try:
+                data_inner[str(section + 1)] = dataset[0][section]
+            except Exception as e:
+                data_inner[str(section + 1)] = str(e)
+        data_inner["#default"] = "请输入正确的选项名！"
+        data[sat] = AllUp_utils.wikitext.build_switch(data_inner)
+    data["#default"] = "请输入正确的卫星名！"
+    return AllUp_utils.wikitext.build_switch(data)
+
 
 def make(id):
-  """Main switch function."""
-  match id:
-    case 't':
-      return strftime('%Y年%m月%d日%H时', localtime())
-    case '1':
-      return '因上游数据进行格式调整，<code><nowiki>{{AllUp|1}}</nowiki></code> 暂时停用！{{需要更新}}'
-      # return fetch_voyager_data()
-    case '2':
-      return fetch_orbital_data()
-    case '3':
-      return fetch_starlink_data()
-    case '4':
-      return build_tiangong_chart()
-    case '5':
-      return fetch_satellite_data()
-    case _:
-      return '请输入正确的AllUp编号！'
+    """Main switch function."""
+    match id:
+        case "t":
+            return strftime("%Y年%m月%d日%H时", localtime())
+        case "1":
+            return "因上游数据进行格式调整，<code><nowiki>{{AllUp|1}}</nowiki></code> 暂时停用！{{需要更新}}"
+            # return fetch_voyager_data()
+        case "2":
+            return fetch_orbital_data()
+        case "3":
+            return fetch_starlink_data()
+        case "4":
+            return build_tiangong_chart()
+        case "5":
+            return fetch_satellite_data()
+        case _:
+            return "请输入正确的AllUp编号！"
 
-if __name__ == '__main__':
-  print('001')
-  test = AllUp_utils.wiki.pull('神舟二十号')
-  print('002')
-  print(test)
-  print('003')
-  print('000')
+
+if __name__ == "__main__":
+    chromedriver = AllUp_utils.web.configure_chromedriver()
+    AllUp_data = {"switch_key": "1"}
+    for dataset in ["t"] + [str(i + 1) for i in range(5)] + ["#default"]:
+        AllUp_data[dataset] = make(dataset)
+    AllUp_content = f"<includeonly>{AllUp_utils.wikitext.build_switch(AllUp_data)}</includeonly><noinclude>[[Category:模板]]{{{{documentation}}}}</noinclude>"
+    AllUp_utils.wiki.push("AllUp", "MAIN", AllUp_content)


### PR DESCRIPTION
Enhance authenticated interactions with Satwiki by injecting X-authkey into HTTP sessions, refactor `wiki` utility logic and environment flag checks, bump CI Python version, and update documentation and Dependabot schedules

New Features:
- Include X-authkey header in all HTTP sessions for authenticated Satwiki interactions

Enhancements:
- Refactor `wiki` utilities to conditionally instantiate the Wiki client based on main branch, workflow dispatch, or pull request contexts
- Streamline and reformat code across modules, including consolidating Selenium Chrome options and adjusting function formatting

CI:
- Bump GitHub Actions Python version from 3.12 to 3.13 and inject `BOT_PASSWORD` and `X_AUTHKEY` secrets into the workflow

Documentation:
- Update README to reflect project rename to AllUp-Satwiki and simplify the schedule footnote

Chores:
- Align Dependabot update schedule to use `cron` syntax matching the CI schedule